### PR TITLE
Feature load_compiled

### DIFF
--- a/ashes.py
+++ b/ashes.py
@@ -249,7 +249,7 @@ class PartialTag(Tag):
                 pe.token = self
                 raise
 
-        ## tying to make this more standardized
+        # tying to make this more standardized
         inline_body = inline_to_dust_ast(self.subtokens)
         return [['partial',
                  inline_body,
@@ -626,7 +626,7 @@ def _python_compile(source, name, global_env=None):
     else:
         exec("exec code in global_env")
     return global_env[name]
-    
+
 
 def compile_python_string(python_string):
     """utility function
@@ -1265,7 +1265,8 @@ class Context(object):
                 else:
                     ctx = value
             else:
-                #if scope is limited by a leading dot, don't search up the tree
+                #  if scope is limited by a leading dot,
+                #  don't search up the tree
                 if first_path_element in ctx.head:
                     ctx = ctx.head[first_path_element]
                 else:
@@ -1338,7 +1339,7 @@ class Stack(object):
         self.tail = tail
         self.index = index or 0
         self.of = length or 1
-        #self.is_object = is_scalar(head)
+        #  self.is_object = is_scalar(head)
 
     def __repr__(self):
         return 'Stack(%r, %r, %r, %r)' % (self.head,
@@ -1760,8 +1761,8 @@ class Template(object):
         args:
             ``path``
         kwargs:
-            ``name`` default ``None``.  
-            ``encoding`` default ``utf-8``.  
+            ``name`` default ``None``.
+            ``encoding`` default ``utf-8``.
         """
         abs_path = os.path.abspath(path)
         if not os.path.isfile(abs_path):
@@ -1779,7 +1780,7 @@ class Template(object):
         args:
             ``ast``
         kwargs:
-            ``name`` default ``None``.  
+            ``name`` default ``None``.
         """
         template = cls(name=name, source='', lazy=True, **kw)
         template.render_func = template._ast_to_render_func(ast)
@@ -1792,7 +1793,7 @@ class Template(object):
         args:
             ``python_string``
         kwargs:
-            ``name`` default ``None``.  
+            ``name`` default ``None``.
         """
         template = cls(name=name, source='', lazy=True, **kw)
         compiler = Compiler(template.env)
@@ -1806,34 +1807,34 @@ class Template(object):
         args:
             ``python_compiled``
         kwargs:
-            ``name`` default ``None``.  
+            ``name`` default ``None``.
         """
         template = cls(name=name, source='', lazy=True, **kw)
         template.render_func = python_compiled
         return template
-        
+
     def to_ast(self, optimize=True, raw=False):
         """Generates the AST for a given template.
-        
+
         kwargs:
-            ``optimize`` default ``True``.  
-            ``raw`` default ``False``.  
-        
+            ``optimize`` default ``True``.
+            ``raw`` default ``False``.
+
         Note: this is just a public function for `_get_ast`
         """
         return self._get_ast(optimize=optimize, raw=raw)
-        
+
     def to_python_string(self, optimize=True):
         """Generates the Python string representation for a template.
 
         kwargs:
-            ``optimize`` default ``True``.  
+            ``optimize`` default ``True``.
 
         Note: this is just a public function for `_get_render_func`
         """
         python_string = self._get_render_func(optimize=optimize, ret_str=True)
         return python_string
-        
+
     def render(self, model, env=None):
         env = env or self.env
         rendered = []
@@ -1885,9 +1886,9 @@ class Template(object):
             return Compiler(self.env)._gen_python(ast)
         func = self._ast_to_render_func(ast)
         return func
-    
+
     def _ast_to_render_func(self, ast):
-        # making this a shared function between 
+        # making this a shared function between
         # `_get_render_func` and ast loaders
         compiler = Compiler(self.env)
         func = compiler.compile(ast)
@@ -1981,16 +1982,16 @@ class BaseAshesEnv(object):
     def render(self, name, model):
         tmpl = self.load(name)
         return tmpl.render(model, self)
-        
+
     def generate_ast(self, name, optimize=True):
         """Generates the AST for a given template.
-        This works by first loading the template (via normal means) then 
+        This works by first loading the template (via normal means) then
         calling the template's ``to_ast()`` method.
-        
+
         args:
             ``name``  template name
         kwargs:
-            ``optimize`` default ``True``.  
+            ``optimize`` default ``True``.
             passed to ``to_ast()`` method of the template.
         """
         template = self.load(name)
@@ -1999,32 +2000,32 @@ class BaseAshesEnv(object):
 
     def generate_python_string(self, name, optimize=True):
         """Generates the Python string representation of a template.
-        This works by first loading the template (via normal means) then 
+        This works by first loading the template (via normal means) then
         calling the template's ``to_python_string`` method.
 
         You can register a string back with ``load_template_python_string``
-        Note: If you are in a somewhat persistant environment, it is much 
-        faster to first compile the string with ``ashes.compile_python_string`` 
+        Note: If you are in a somewhat persistant environment, it is much
+        faster to first compile the string with ``ashes.compile_python_string``
         then register with ``load_template_python_compiled``
 
         args:
             ``name``  template name
         kwargs:
-            ``optimize`` default ``True``.  
+            ``optimize`` default ``True``.
             passed to ``to_python_string()`` method of the template.
         """
         template = self.load(name)
         python_string = template.to_python_string(optimize=optimize)
         return python_string
-    
+
     def load_template_ast(self, name, ast, optimized=True):
         """Loads and registers a template via the AST representation.
-        
+
         args:
             ``name``  template name
             ``ast``  template ast (via ``generate_ast``)
         kwargs:
-            ``optimized`` default ``True``.  
+            ``optimized`` default ``True``.
             passed to ``__init__()`` method of the template as ``optimize``.
         """
         template = self.template_type(name, source='', lazy=True, optimize=optimized)
@@ -2034,8 +2035,8 @@ class BaseAshesEnv(object):
 
     def load_template_python_string(self, name, python_string, optimized=True):
         """Loads and registers a template via the python string representation.
-        
-        This offers a slight performance boost to ``load_template_ast`` but is 
+
+        This offers a slight performance boost to ``load_template_ast`` but is
         not nearly as efficient as caching and providing the compiled python as
         supported in ``load_template_python_compiled``
 
@@ -2043,7 +2044,7 @@ class BaseAshesEnv(object):
             ``name``  template name
             ``python_string``  template string (via ``generate_python_string``)
         kwargs:
-            ``optimized`` default ``True``.  
+            ``optimized`` default ``True``.
             passed to ``__init__()`` method of the template as ``optimize``.
         """
         template = self.template_type(name, '', lazy=True, optimize=optimized)
@@ -2060,10 +2061,10 @@ class BaseAshesEnv(object):
 
         args:
             ``name``  template name
-            ``python_compiled`` template 
-              via ``generate_python_string`` and ``ashes.compile_python_string`` 
+            ``python_compiled`` template
+              via ``generate_python_string`` and ``ashes.compile_python_string``
         kwargs:
-            ``optimized`` default ``True``.  
+            ``optimized`` default ``True``.
             passed to ``__init__()`` method of the template as ``optimize``.
         """
         template = self.template_type(name, '', lazy=True, optimize=optimized)
@@ -2357,14 +2358,14 @@ def _main():
                 '{/eq}'
                 ', {@size key=hello/} characters')
         ashes.register_source('hi', tmpl)
-        #print(ashes.render('hi', {'hello': lambda x: None}))
+        #  print(ashes.render('hi', {'hello': lambda x: None}))
     except Exception as e:
-        import pdb;pdb.post_mortem()
+        import pdb; pdb.post_mortem()
         raise
 
     ae = AshesEnv(filters={'cn': comma_num})
     ae.register_source('cn_tmpl', 'comma_numd: {thing|cn}')
-    #print(ae.render('cn_tmpl', {'thing': 21000}))
+    #  print(ae.render('cn_tmpl', {'thing': 21000}))
     ae.register_source('tmpl', '{`{ok}thing`}')
     print(ae.render('tmpl', {'thing': 21000}))
 

--- a/ashes.py
+++ b/ashes.py
@@ -681,7 +681,9 @@ def _python_compile(source, name, global_env=None):
     
 
 def compile_python_string(python_string):
-    """utility function"""
+    """utility function
+    used to compile python string functions for template loading
+    """
     return _python_compile(python_string, 'render')
 
 
@@ -1974,7 +1976,11 @@ class BaseAshesEnv(object):
         return _ast
 
     def generate_python_string(self, name, optimize=True):
-        """generates the Python string representation for a template."""
+        """generates the Python string representation for a template.
+        register it back with `load_template_python_string`
+        it is MUCH FASTER to first compile it with `compile_python_string()` 
+        then register with `cls.load_template_python_compiled`
+        """
         _template = self._load_template(name)
         _python = _template._get_render_func(optimize=True, ret_str=True)
         return _python
@@ -1989,7 +1995,7 @@ class BaseAshesEnv(object):
 
     def load_template_python_string(self, name, python_string, optimized=True):
         """registers the Python string representation for a template.
-            this has little saves.  better to `load_template_python_compiled`
+            this has little saves.  better to `cls.load_template_python_compiled`
         """
         template = self.template_type(name, '', lazy=True, optimize=optimized)
         compiler = Compiler(template.env)
@@ -1998,8 +2004,9 @@ class BaseAshesEnv(object):
         return template
 
     def load_template_python_compiled(self, name, python_compiled, optimized=True):
-        """registers the Python string representation for a template.
-            this has little saves.  better to `load_template_python_compiled`
+        """registers the compiled Python string representation for a template.
+        see `cls.generate_python_string` to generate the string
+        see `compile_python_string` to compile
         """
         template = self.template_type(name, '', lazy=True, optimize=optimized)
         template.render_func = python_compiled

--- a/ashes.py
+++ b/ashes.py
@@ -631,6 +631,9 @@ def _python_compile(source, name, global_env=None):
 def compile_python_string(python_string):
     """utility function
     used to compile python string functions for template loading
+    
+    args:
+        ``python_string``
     """
     return _python_compile(python_string, 'render')
 
@@ -1888,8 +1891,9 @@ class Template(object):
         return func
 
     def _ast_to_render_func(self, ast):
-        # making this a shared function between
-        # `_get_render_func` and ast loaders
+        """this was part of ``_get_render_func`` but is better implemented
+        as an separate function so that AST can be directly loaded.
+        """
         compiler = Compiler(self.env)
         func = compiler.compile(ast)
         return func

--- a/tests_jv-templates/all.dust
+++ b/tests_jv-templates/all.dust
@@ -1,0 +1,7 @@
+All
+<ul>
+	<li>{>"bananas.dust"/}</li>
+	<li>{>"citrus.dust"/}</li>
+	<li>{>"dragonfruit.dust"/}</li>
+	<li>{>"elderflower.dust"/}</li>
+</ul>

--- a/tests_jv-templates/apples.dust
+++ b/tests_jv-templates/apples.dust
@@ -1,0 +1,37 @@
+<ul>
+	<li>apples</li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+</ul>

--- a/tests_jv-templates/bananas.dust
+++ b/tests_jv-templates/bananas.dust
@@ -1,0 +1,3 @@
+<ul>
+	<li>bananas</li>
+</ul>

--- a/tests_jv-templates/citrus.dust
+++ b/tests_jv-templates/citrus.dust
@@ -1,0 +1,3 @@
+<ul>
+	<li>citrus</li>
+</ul>

--- a/tests_jv-templates/dragonfruit.dust
+++ b/tests_jv-templates/dragonfruit.dust
@@ -1,0 +1,3 @@
+<ul>
+	<li>dragonfruit</li>
+</ul>

--- a/tests_jv-templates/elderflower.dust
+++ b/tests_jv-templates/elderflower.dust
@@ -1,0 +1,3 @@
+<ul>
+	<li>elderflower</li>
+</ul>

--- a/tests_jv-templates/oranges.dust
+++ b/tests_jv-templates/oranges.dust
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<body>
+<ul>
+	<li>oranges
+		{>"apples.dust"/}
+	</li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+	<li></li>
+</ul>
+</body>
+</html>

--- a/tests_jv.py
+++ b/tests_jv.py
@@ -20,8 +20,8 @@ PRINT_SAMPLE = False
 # ==============================================================================
 
 
-
 # test the baseline
+
 
 @tests_jv_utils.timeit
 def test_baseline():
@@ -35,7 +35,8 @@ def test_baseline():
 _sample = None
 for i in range(0, ITERATIONS):
     test_baseline()
-    
+
+
 if PRINT_SAMPLE:
     print "========================"
     print "Normal method"
@@ -55,6 +56,7 @@ ashesEnv = ashes.AshesEnv(loaders=(ashesLoader, ))
 ast__oranges = ashesEnv.generate_ast('oranges.dust')
 ast__apples = ashesEnv.generate_ast('apples.dust')
 
+
 @tests_jv_utils.timeit
 def test_ast():
     ashesLoader = ashes.TemplatePathLoader('tests_jv-templates')
@@ -65,9 +67,11 @@ def test_ast():
     if PRINT_SAMPLE and i == 0:
         _sample = templated
 
+
 _sample = None
 for i in range(0, ITERATIONS):
     test_ast()
+
 
 if PRINT_SAMPLE:
     print "========================"
@@ -83,12 +87,14 @@ if PRINT_SAMPLE:
 
 # test a loaded python_string method
 
+
 ashesLoader = ashes.TemplatePathLoader('tests_jv-templates')
 ashesEnv = ashes.AshesEnv(loaders=(ashesLoader, ))
 python_string__oranges = ashesEnv.generate_python_string('oranges.dust')
 python_string__apples = ashesEnv.generate_python_string('apples.dust')
 python_function__oranges = ashes.compile_python_string(python_string__oranges)
 python_function__apples = ashes.compile_python_string(python_string__apples)
+
 
 @tests_jv_utils.timeit
 def test_python_string():
@@ -100,9 +106,11 @@ def test_python_string():
     if PRINT_SAMPLE and i == 0:
         _sample = templated
 
+
 _sample = None
 for i in range(0, ITERATIONS):
     test_python_string()
+
 
 if PRINT_SAMPLE:
     print "========================"
@@ -122,9 +130,11 @@ def test_python_compiled():
     if PRINT_SAMPLE and i == 0:
         _sample = templated
 
+
 _sample = None
 for i in range(0, ITERATIONS):
     test_python_compiled()
+
 
 if PRINT_SAMPLE:
     print "========================"

--- a/tests_jv.py
+++ b/tests_jv.py
@@ -1,13 +1,19 @@
+"""
+This is just a quick file to bench test the various ways of loading data
+
+
+"""
+
 import ashes
 import pprint
-
+import tests_jv_utils
 
 # ==============================================================================
 # ==============================================================================
 
 
 ITERATIONS = 1000
-PRINT_SAMPLE = True
+PRINT_SAMPLE = False
 
 
 # ==============================================================================
@@ -17,19 +23,25 @@ PRINT_SAMPLE = True
 
 # test the baseline
 
-_sample = None
-for i in range(0, ITERATIONS):
+@tests_jv_utils.timeit
+def test_baseline():
     ashesLoader = ashes.TemplatePathLoader('tests_jv-templates')
     ashesEnv = ashes.AshesEnv(loaders=(ashesLoader, ))
     templated = ashesEnv.render('oranges.dust', {})
     if PRINT_SAMPLE and i == 0:
         _sample = templated
-print "========================"
-print "Normal method"
-ashes.print_timed()
-ashes.timeditems = {}
-print _sample
-print "========================"
+
+
+_sample = None
+for i in range(0, ITERATIONS):
+    test_baseline()
+    
+if PRINT_SAMPLE:
+    print "========================"
+    print "Normal method"
+    tests_jv_utils.print_timed()
+    print _sample
+    print "========================"
 
 
 # ==============================================================================
@@ -43,8 +55,8 @@ ashesEnv = ashes.AshesEnv(loaders=(ashesLoader, ))
 ast__oranges = ashesEnv.generate_ast('oranges.dust')
 ast__apples = ashesEnv.generate_ast('apples.dust')
 
-_sample = None
-for i in range(0, ITERATIONS):
+@tests_jv_utils.timeit
+def test_ast():
     ashesLoader = ashes.TemplatePathLoader('tests_jv-templates')
     ashesEnv = ashes.AshesEnv(loaders=(ashesLoader, ))
     ashesEnv.load_template_ast('oranges.dust', ast__oranges)
@@ -52,12 +64,17 @@ for i in range(0, ITERATIONS):
     templated = ashesEnv.render('oranges.dust', {})
     if PRINT_SAMPLE and i == 0:
         _sample = templated
-print "========================"
-print "Loaded AST method"
-ashes.print_timed()
-ashes.timeditems = {}
-print _sample
-print "========================"
+
+_sample = None
+for i in range(0, ITERATIONS):
+    test_ast()
+
+if PRINT_SAMPLE:
+    print "========================"
+    print "Loaded AST method"
+    tests_jv_utils.print_timed()
+    print _sample
+    print "========================"
 
 
 # ==============================================================================
@@ -73,8 +90,30 @@ python_string__apples = ashesEnv.generate_python_string('apples.dust')
 python_function__oranges = ashes.compile_python_string(python_string__oranges)
 python_function__apples = ashes.compile_python_string(python_string__apples)
 
+@tests_jv_utils.timeit
+def test_python_string():
+    ashesLoader = ashes.TemplatePathLoader('tests_jv-templates')
+    ashesEnv = ashes.AshesEnv(loaders=(ashesLoader, ))
+    _loaded = ashesEnv.load_template_python_string('oranges.dust', python_string__oranges)
+    _loaded = ashesEnv.load_template_python_string('apples.dust', python_string__apples)
+    templated = ashesEnv.render('oranges.dust', {})
+    if PRINT_SAMPLE and i == 0:
+        _sample = templated
+
 _sample = None
 for i in range(0, ITERATIONS):
+    test_python_string()
+
+if PRINT_SAMPLE:
+    print "========================"
+    print "Loaded Python String method"
+    tests_jv_utils.print_timed()
+    print _sample
+    print "========================"
+
+
+@tests_jv_utils.timeit
+def test_python_compiled():
     ashesLoader = ashes.TemplatePathLoader('tests_jv-templates')
     ashesEnv = ashes.AshesEnv(loaders=(ashesLoader, ))
     _loaded = ashesEnv.load_template_python_compiled('oranges.dust', python_function__oranges)
@@ -82,9 +121,18 @@ for i in range(0, ITERATIONS):
     templated = ashesEnv.render('oranges.dust', {})
     if PRINT_SAMPLE and i == 0:
         _sample = templated
-print "========================"
-print "Loaded Python String method"
-ashes.print_timed()
-ashes.timeditems = {}
-print _sample
-print "========================"
+
+_sample = None
+for i in range(0, ITERATIONS):
+    test_python_compiled()
+
+if PRINT_SAMPLE:
+    print "========================"
+    print "Loaded Python Compiled method"
+    tests_jv_utils.print_timed()
+    print _sample
+    print "========================"
+
+
+if not PRINT_SAMPLE:
+    tests_jv_utils.timed_stats()

--- a/tests_jv.py
+++ b/tests_jv.py
@@ -1,0 +1,90 @@
+import ashes
+import pprint
+
+
+# ==============================================================================
+# ==============================================================================
+
+
+ITERATIONS = 1000
+PRINT_SAMPLE = True
+
+
+# ==============================================================================
+# ==============================================================================
+
+
+
+# test the baseline
+
+_sample = None
+for i in range(0, ITERATIONS):
+    ashesLoader = ashes.TemplatePathLoader('tests_jv-templates')
+    ashesEnv = ashes.AshesEnv(loaders=(ashesLoader, ))
+    templated = ashesEnv.render('oranges.dust', {})
+    if PRINT_SAMPLE and i == 0:
+        _sample = templated
+print "========================"
+print "Normal method"
+ashes.print_timed()
+ashes.timeditems = {}
+print _sample
+print "========================"
+
+
+# ==============================================================================
+# ==============================================================================
+# ==============================================================================
+
+# test a loaded ast method
+
+ashesLoader = ashes.TemplatePathLoader('tests_jv-templates')
+ashesEnv = ashes.AshesEnv(loaders=(ashesLoader, ))
+ast__oranges = ashesEnv.generate_ast('oranges.dust')
+ast__apples = ashesEnv.generate_ast('apples.dust')
+
+_sample = None
+for i in range(0, ITERATIONS):
+    ashesLoader = ashes.TemplatePathLoader('tests_jv-templates')
+    ashesEnv = ashes.AshesEnv(loaders=(ashesLoader, ))
+    ashesEnv.load_template_ast('oranges.dust', ast__oranges)
+    ashesEnv.load_template_ast('apples.dust', ast__apples)
+    templated = ashesEnv.render('oranges.dust', {})
+    if PRINT_SAMPLE and i == 0:
+        _sample = templated
+print "========================"
+print "Loaded AST method"
+ashes.print_timed()
+ashes.timeditems = {}
+print _sample
+print "========================"
+
+
+# ==============================================================================
+# ==============================================================================
+# ==============================================================================
+
+# test a loaded python_string method
+
+ashesLoader = ashes.TemplatePathLoader('tests_jv-templates')
+ashesEnv = ashes.AshesEnv(loaders=(ashesLoader, ))
+python_string__oranges = ashesEnv.generate_python_string('oranges.dust')
+python_string__apples = ashesEnv.generate_python_string('apples.dust')
+python_function__oranges = ashes.compile_python_string(python_string__oranges)
+python_function__apples = ashes.compile_python_string(python_string__apples)
+
+_sample = None
+for i in range(0, ITERATIONS):
+    ashesLoader = ashes.TemplatePathLoader('tests_jv-templates')
+    ashesEnv = ashes.AshesEnv(loaders=(ashesLoader, ))
+    _loaded = ashesEnv.load_template_python_compiled('oranges.dust', python_function__oranges)
+    _loaded = ashesEnv.load_template_python_compiled('apples.dust', python_function__apples)
+    templated = ashesEnv.render('oranges.dust', {})
+    if PRINT_SAMPLE and i == 0:
+        _sample = templated
+print "========================"
+print "Loaded Python String method"
+ashes.print_timed()
+ashes.timeditems = {}
+print _sample
+print "========================"

--- a/tests_jv_loader.py
+++ b/tests_jv_loader.py
@@ -20,16 +20,19 @@ import pprint
 import os
 import os.path
 
+import tests_jv_utils
+
 # ==============================================================================
 # ==============================================================================
 
 DEBUG_TEMPLATE_LOADING = True
 OPTIMIZE_VIA = 'python_compiled'  # ['template', 'ast', 'python_string', 'python_compiled']
+ITERATIONS = 1000
 
 # ==============================================================================
 # ==============================================================================
 
-ashes__default_env = ashes.AshesEnv(keep_whitespace=True)
+ashes__default_env = ashes.AshesEnv()
 
 globalCache = {
     'template': {},
@@ -38,18 +41,24 @@ globalCache = {
     'python_compiled': {},
 }
 
+
 class CustomAshesLoader(object):
     """Class for Ashes (dust.js in Python) template loading.
         This is a support class, used to proxy missing template requests by the Ashes environment into our custom template loader.
+        This probably should have been 4 different loaders.  oh well!
     """
 
     def __init__(self, root_path, exts=None, encoding='utf-8'):
         self.root_path = os.path.normpath(root_path)
         self.encoding = encoding
 
+
+class LoaderStd(CustomAshesLoader):
+    """this does a normal load"""
+    
     def load(self, path, env=None):
         if DEBUG_TEMPLATE_LOADING:
-            log.debug("CustomAshesLoader.load('%s')" % path)
+            log.debug("LoaderStd.load('%s')" % path)
         env = env or ashes__default_env
         norm_path = os.path.normpath(path)
         if path.startswith('../'):
@@ -59,45 +68,67 @@ class CustomAshesLoader(object):
         abs_path = os.path.abspath(norm_path)
         template_name = os.path.relpath(abs_path, self.root_path)
         template_type = env.template_type
-        if OPTIMIZE_VIA == 'template':
-            if abs_path in globalCache['template']:
-                log.debug("using globalCache['template']['%s']" % abs_path)
-                return globalCache['template'][abs_path]
-        elif OPTIMIZE_VIA == 'ast':
-            if abs_path in globalCache['ast']:
-                log.debug("using globalCache['ast']['%s']" % abs_path)
-                ast = globalCache['ast'][abs_path]
-                template = template_type.from_ast(name=template_name,
-                                               ast=ast,
-                                               env=env)   
-                return template
-        elif OPTIMIZE_VIA == 'python_string':
-            if abs_path in globalCache['python_string']:
-                log.debug("using globalCache['python_string']['%s']" % abs_path)
-                python_string = globalCache['python_string'][abs_path]
-                template = template_type.from_python_string(name=template_name,
-                                               python_string=python_string,
-                                               env=env)   
-                return template
-        elif OPTIMIZE_VIA == 'python_compiled':
-            if abs_path in globalCache['python_compiled']:
-                log.debug("using globalCache['python_compiled']['%s']" % abs_path)
-                python_string_compiled = globalCache['python_compiled'][abs_path]
-                template = template_type.from_python_compiled(name=template_name,
-                                               python_compiled=python_string_compiled,
-                                               env=env)   
-                return template
-        if OPTIMIZE_VIA == 'template':
-            print "name=template_name (%s)" % template_name
-            print "path=abs_path (%s)" % abs_path
+
+        template = template_type.from_path(name=template_name,
+                                           path=abs_path,
+                                           encoding=self.encoding,
+                                           keep_source=True,
+                                           env=env)
+        return template
+
+
+class LoaderTemplate(CustomAshesLoader):
+    """this caches template objects"""
+
+    def load(self, path, env=None):
+        if DEBUG_TEMPLATE_LOADING:
+            log.debug("LoaderTemplate.load('%s')" % path)
+        env = env or ashes__default_env
+        norm_path = os.path.normpath(path)
+        if path.startswith('../'):
+            raise ValueError('no traversal above loader root path: %r' % path)
+        if not path.startswith(self.root_path):
+            norm_path = os.path.join(self.root_path, norm_path)
+        abs_path = os.path.abspath(norm_path)
+        template_name = os.path.relpath(abs_path, self.root_path)
+        template_type = env.template_type
+
+        if abs_path in globalCache['template']:
+            log.debug("using globalCache['template']['%s']" % abs_path)
+            template = globalCache['template'][abs_path]
+        else:
             template = template_type.from_path(name=template_name,
                                                path=abs_path,
                                                encoding=self.encoding,
-                                               keep_source = True,
-                                               env=env)        
+                                               keep_source=True,
+                                               env=env)
             globalCache['template'][abs_path] = template
-        elif OPTIMIZE_VIA == 'ast':
-            # load it first
+        return template
+
+
+class LoaderAST(CustomAshesLoader):
+    """this caches template AST"""
+
+    def load(self, path, env=None):
+        if DEBUG_TEMPLATE_LOADING:
+            log.debug("LoaderAST.load('%s')" % path)
+        env = env or ashes__default_env
+        norm_path = os.path.normpath(path)
+        if path.startswith('../'):
+            raise ValueError('no traversal above loader root path: %r' % path)
+        if not path.startswith(self.root_path):
+            norm_path = os.path.join(self.root_path, norm_path)
+        abs_path = os.path.abspath(norm_path)
+        template_name = os.path.relpath(abs_path, self.root_path)
+        template_type = env.template_type
+
+        if abs_path in globalCache['ast']:
+            log.debug("using globalCache['ast']['%s']" % abs_path)
+            ast = globalCache['ast'][abs_path]
+            template = template_type.from_ast(name=template_name,
+                                              ast=ast,
+                                              env=env)
+        else:
             template = template_type.from_path(name=template_name,
                                                path=abs_path,
                                                encoding=self.encoding,
@@ -105,7 +136,32 @@ class CustomAshesLoader(object):
                                                env=env)
             ast = template.to_ast()
             globalCache['ast'][abs_path] = ast
-        elif OPTIMIZE_VIA == 'python_string':
+        return template
+
+
+class LoaderPythonString(CustomAshesLoader):
+    """this caches template python strings"""
+
+    def load(self, path, env=None):
+        if DEBUG_TEMPLATE_LOADING:
+            log.debug("LoaderPythonString.load('%s')" % path)
+        env = env or ashes__default_env
+        norm_path = os.path.normpath(path)
+        if path.startswith('../'):
+            raise ValueError('no traversal above loader root path: %r' % path)
+        if not path.startswith(self.root_path):
+            norm_path = os.path.join(self.root_path, norm_path)
+        abs_path = os.path.abspath(norm_path)
+        template_name = os.path.relpath(abs_path, self.root_path)
+        template_type = env.template_type
+
+        if abs_path in globalCache['python_string']:
+            log.debug("using globalCache['python_string']['%s']" % abs_path)
+            python_string = globalCache['python_string'][abs_path]
+            template = template_type.from_python_string(name=template_name,
+                                                        python_string=python_string,
+                                                        env=env)
+        else:
             template = template_type.from_path(name=template_name,
                                                path=abs_path,
                                                encoding=self.encoding,
@@ -113,7 +169,32 @@ class CustomAshesLoader(object):
                                                env=env)
             python_string = template.to_python_string()
             globalCache['python_string'][abs_path] = python_string
-        elif OPTIMIZE_VIA == 'python_compiled':
+        return template
+
+
+class LoaderPythonCompiled(CustomAshesLoader):
+    """this caches template python defs (compiled)"""
+
+    def load(self, path, env=None):
+        if DEBUG_TEMPLATE_LOADING:
+            log.debug("LoaderPythonCompiled.load('%s')" % path)
+        env = env or ashes__default_env
+        norm_path = os.path.normpath(path)
+        if path.startswith('../'):
+            raise ValueError('no traversal above loader root path: %r' % path)
+        if not path.startswith(self.root_path):
+            norm_path = os.path.join(self.root_path, norm_path)
+        abs_path = os.path.abspath(norm_path)
+        template_name = os.path.relpath(abs_path, self.root_path)
+        template_type = env.template_type
+
+        if abs_path in globalCache['python_compiled']:
+            log.debug("using globalCache['python_compiled']['%s']" % abs_path)
+            python_string_compiled = globalCache['python_compiled'][abs_path]
+            template = template_type.from_python_compiled(name=template_name,
+                                                          python_compiled=python_string_compiled,
+                                                          env=env)
+        else:
             template = template_type.from_path(name=template_name,
                                                path=abs_path,
                                                encoding=self.encoding,
@@ -125,19 +206,71 @@ class CustomAshesLoader(object):
         return template
 
 
-def test_1(iteration=1):
+@tests_jv_utils.timeit
+def test_LoaderStd(iteration=1):
     if DEBUG_TEMPLATE_LOADING:
-        log.debug("===================== test_1 | %s" % iteration)
-    ashesLoader = CustomAshesLoader('tests_jv-templates')
-    ashesEnv = ashes.AshesEnv(loaders=(ashesLoader,), keep_whitespace=True)
+        log.debug("===================== LoaderStd | %s" % iteration)
+    ashesLoader = LoaderStd('tests_jv-templates')
+    ashesEnv = ashes.AshesEnv(loaders=(ashesLoader,), )
     templated = ashesEnv.render('all.dust', {})
-    # print templated
+
+
+@tests_jv_utils.timeit
+def test_Template(iteration=1):
+    if DEBUG_TEMPLATE_LOADING:
+        log.debug("===================== test_Template | %s" % iteration)
+    ashesLoader = LoaderTemplate('tests_jv-templates')
+    ashesEnv = ashes.AshesEnv(loaders=(ashesLoader,), )
+    templated = ashesEnv.render('all.dust', {})
+
+
+@tests_jv_utils.timeit
+def test_AST(iteration=1):
+    if DEBUG_TEMPLATE_LOADING:
+        log.debug("===================== test_AST | %s" % iteration)
+    ashesLoader = LoaderAST('tests_jv-templates')
+    ashesEnv = ashes.AshesEnv(loaders=(ashesLoader,), )
+    templated = ashesEnv.render('all.dust', {})
+
+
+@tests_jv_utils.timeit
+def test_PythonString(iteration=1):
+    if DEBUG_TEMPLATE_LOADING:
+        log.debug("===================== test_PythonString | %s" % iteration)
+    ashesLoader = LoaderPythonString('tests_jv-templates')
+    ashesEnv = ashes.AshesEnv(loaders=(ashesLoader,), )
+    templated = ashesEnv.render('all.dust', {})
+
+
+@tests_jv_utils.timeit
+def test_PythonCompiled(iteration=1):
+    if DEBUG_TEMPLATE_LOADING:
+        log.debug("===================== test_PythonCompiled | %s" % iteration)
+    ashesLoader = LoaderPythonCompiled('tests_jv-templates')
+    ashesEnv = ashes.AshesEnv(loaders=(ashesLoader,), )
+    templated = ashesEnv.render('all.dust', {})
 
 
 if __name__ == '__main__':
-    log.setLevel(logging.DEBUG)
-    ch = logging.StreamHandler()
-    ch.setLevel(logging.DEBUG)
-    log.addHandler(ch)
-    for i in range(1,10):
-        test_1(i)
+    if False:
+        log.setLevel(logging.DEBUG)
+        ch = logging.StreamHandler()
+        ch.setLevel(logging.DEBUG)
+        log.addHandler(ch)
+
+    for i in range(1, ITERATIONS):
+        test_LoaderStd(i)
+
+    for i in range(1, ITERATIONS):
+        test_Template(i)
+
+    for i in range(1, ITERATIONS):
+        test_AST(i)
+
+    for i in range(1, ITERATIONS):
+        test_PythonString(i)
+
+    for i in range(1, ITERATIONS):
+        test_PythonCompiled(i)
+
+    tests_jv_utils.timed_stats()

--- a/tests_jv_loader.py
+++ b/tests_jv_loader.py
@@ -1,0 +1,143 @@
+"""
+this uses a custom loader to test different ways of laoding data
+
+it was used more for API/interface development and testing
+
+toggle the ``OPTIMIZE_VIA`` variable to test the different kinds
+
+note that the globalCache is used to save the data, and then templates are generated
+off of that
+
+
+"""
+import logging
+log = logging.getLogger(__name__)
+
+import ashes
+import simplejson as json
+import pdb
+import pprint
+import os
+import os.path
+
+# ==============================================================================
+# ==============================================================================
+
+DEBUG_TEMPLATE_LOADING = True
+OPTIMIZE_VIA = 'python_compiled'  # ['template', 'ast', 'python_string', 'python_compiled']
+
+# ==============================================================================
+# ==============================================================================
+
+ashes__default_env = ashes.AshesEnv(keep_whitespace=True)
+
+globalCache = {
+    'template': {},
+    'ast': {},
+    'python_string': {},
+    'python_compiled': {},
+}
+
+class CustomAshesLoader(object):
+    """Class for Ashes (dust.js in Python) template loading.
+        This is a support class, used to proxy missing template requests by the Ashes environment into our custom template loader.
+    """
+
+    def __init__(self, root_path, exts=None, encoding='utf-8'):
+        self.root_path = os.path.normpath(root_path)
+        self.encoding = encoding
+
+    def load(self, path, env=None):
+        if DEBUG_TEMPLATE_LOADING:
+            log.debug("CustomAshesLoader.load('%s')" % path)
+        env = env or ashes__default_env
+        norm_path = os.path.normpath(path)
+        if path.startswith('../'):
+            raise ValueError('no traversal above loader root path: %r' % path)
+        if not path.startswith(self.root_path):
+            norm_path = os.path.join(self.root_path, norm_path)
+        abs_path = os.path.abspath(norm_path)
+        template_name = os.path.relpath(abs_path, self.root_path)
+        template_type = env.template_type
+        if OPTIMIZE_VIA == 'template':
+            if abs_path in globalCache['template']:
+                log.debug("using globalCache['template']['%s']" % abs_path)
+                return globalCache['template'][abs_path]
+        elif OPTIMIZE_VIA == 'ast':
+            if abs_path in globalCache['ast']:
+                log.debug("using globalCache['ast']['%s']" % abs_path)
+                ast = globalCache['ast'][abs_path]
+                template = template_type.from_ast(name=template_name,
+                                               ast=ast,
+                                               env=env)   
+                return template
+        elif OPTIMIZE_VIA == 'python_string':
+            if abs_path in globalCache['python_string']:
+                log.debug("using globalCache['python_string']['%s']" % abs_path)
+                python_string = globalCache['python_string'][abs_path]
+                template = template_type.from_python_string(name=template_name,
+                                               python_string=python_string,
+                                               env=env)   
+                return template
+        elif OPTIMIZE_VIA == 'python_compiled':
+            if abs_path in globalCache['python_compiled']:
+                log.debug("using globalCache['python_compiled']['%s']" % abs_path)
+                python_string_compiled = globalCache['python_compiled'][abs_path]
+                template = template_type.from_python_compiled(name=template_name,
+                                               python_compiled=python_string_compiled,
+                                               env=env)   
+                return template
+        if OPTIMIZE_VIA == 'template':
+            print "name=template_name (%s)" % template_name
+            print "path=abs_path (%s)" % abs_path
+            template = template_type.from_path(name=template_name,
+                                               path=abs_path,
+                                               encoding=self.encoding,
+                                               keep_source = True,
+                                               env=env)        
+            globalCache['template'][abs_path] = template
+        elif OPTIMIZE_VIA == 'ast':
+            # load it first
+            template = template_type.from_path(name=template_name,
+                                               path=abs_path,
+                                               encoding=self.encoding,
+                                               keep_source = True,
+                                               env=env)
+            ast = template.to_ast()
+            globalCache['ast'][abs_path] = ast
+        elif OPTIMIZE_VIA == 'python_string':
+            template = template_type.from_path(name=template_name,
+                                               path=abs_path,
+                                               encoding=self.encoding,
+                                               keep_source = True,
+                                               env=env)
+            python_string = template.to_python_string()
+            globalCache['python_string'][abs_path] = python_string
+        elif OPTIMIZE_VIA == 'python_compiled':
+            template = template_type.from_path(name=template_name,
+                                               path=abs_path,
+                                               encoding=self.encoding,
+                                               keep_source = True,
+                                               env=env)
+            python_string = template.to_python_string()
+            python_string_compiled = ashes.compile_python_string(python_string)
+            globalCache['python_compiled'][abs_path] = python_string_compiled
+        return template
+
+
+def test_1(iteration=1):
+    if DEBUG_TEMPLATE_LOADING:
+        log.debug("===================== test_1 | %s" % iteration)
+    ashesLoader = CustomAshesLoader('tests_jv-templates')
+    ashesEnv = ashes.AshesEnv(loaders=(ashesLoader,), keep_whitespace=True)
+    templated = ashesEnv.render('all.dust', {})
+    # print templated
+
+
+if __name__ == '__main__':
+    log.setLevel(logging.DEBUG)
+    ch = logging.StreamHandler()
+    ch.setLevel(logging.DEBUG)
+    log.addHandler(ch)
+    for i in range(1,10):
+        test_1(i)

--- a/tests_jv_utils.py
+++ b/tests_jv_utils.py
@@ -1,0 +1,62 @@
+""" This bit is about testing timed functions
+
+the @timeit decorator can be applied to functions for timing
+
+the `timed_stats` function will print a nice graph
+the `print_timed` function just prints some row oriented data
+
+"""
+import time
+import operator
+
+timeditems = {}
+
+
+def timeit(method):
+    """decorator method for timing an internal function
+    saves to `timeditems` package var
+    statistics available via `ashes.print_timed`
+    """
+
+    def timed(*args, **kw):
+        ts = time.time()
+        result = method(*args, **kw)
+        te = time.time()
+        if method.__name__ not in timeditems:
+            timeditems[method.__name__] = []
+        timeditems[method.__name__].append( te-ts )
+        return result
+    return timed
+
+
+def print_timed():
+    """displays timing statisics
+    """
+    for k in timeditems.keys():
+        ttl = sum(timeditems[k])
+        avg = float(ttl)/len(timeditems[k]) 
+        print "%s\n\t-- ttl = %s\n\t-- avg = %s\n\t-- its = %s" % ( k, ttl, avg, len(timeditems[k]) )
+
+
+def timed_stats():
+    """displays timing statisics
+    """
+    data = []
+    data = {}
+    for k in timeditems.keys():
+        total = sum(timeditems[k])
+        sample_size = len(timeditems[k])
+        data[k] = {
+            'name': k,
+            'total': total,
+            'average': float(total)/sample_size,
+            'sample_size': sample_size,
+        }
+    data_2 = sorted(data.values(), key=operator.itemgetter('total'))
+    baseline = data_2[-1]
+    template = "{0:25} | {1:25} | {2:25} | {3:25}" # column widths: 8, 10, 15, 7, 10
+    print template.format("test", "average", "total", "baseline") 
+    for idx, i in enumerate(data_2):
+        baseline_shift = (i['total'] / baseline['total']) * 100
+        print template.format(i['name'], i['average'], i['total'], baseline_shift)
+

--- a/tests_jv_utils.py
+++ b/tests_jv_utils.py
@@ -24,7 +24,7 @@ def timeit(method):
         te = time.time()
         if method.__name__ not in timeditems:
             timeditems[method.__name__] = []
-        timeditems[method.__name__].append( te-ts )
+        timeditems[method.__name__].append(te - ts)
         return result
     return timed
 
@@ -34,8 +34,8 @@ def print_timed():
     """
     for k in timeditems.keys():
         ttl = sum(timeditems[k])
-        avg = float(ttl)/len(timeditems[k]) 
-        print "%s\n\t-- ttl = %s\n\t-- avg = %s\n\t-- its = %s" % ( k, ttl, avg, len(timeditems[k]) )
+        avg = float(ttl) / len(timeditems[k])
+        print "%s\n\t-- ttl = %s\n\t-- avg = %s\n\t-- its = %s" % (k, ttl, avg, len(timeditems[k]))
 
 
 def timed_stats():
@@ -49,14 +49,13 @@ def timed_stats():
         data[k] = {
             'name': k,
             'total': total,
-            'average': float(total)/sample_size,
+            'average': float(total) / sample_size,
             'sample_size': sample_size,
         }
     data_2 = sorted(data.values(), key=operator.itemgetter('total'))
     baseline = data_2[-1]
-    template = "{0:25} | {1:25} | {2:25} | {3:25}" # column widths: 8, 10, 15, 7, 10
-    print template.format("test", "average", "total", "baseline") 
+    template = "{0:25} | {1:25} | {2:25} | {3:25}"  # column widths: 8, 10, 15, 7, 10
+    print template.format("test", "average", "total", "baseline")
     for idx, i in enumerate(data_2):
         baseline_shift = (i['total'] / baseline['total']) * 100
         print template.format(i['name'], i['average'], i['total'], baseline_shift)
-


### PR DESCRIPTION
This is more of a request for review than a proper PR, to handle cacheable templates (as in #18). 

The background is that dust javascript handles the caching of template code, and ashes could probably benefit as well.  guess what -- it does.

The approach is simple- AST or python (string/compiled) versions of templates can be extracted and new templates generated from them.  This allows new Ashes Envs/loaders to be created as needed (one per request, etc) from cached versions of the underlying data.

There are 2 files that illustrate this in action:

* tests_jv.py -- raw speed comparison of different template loading strategies
* tests_jv_loader.py -- example of how to load templates via different mechanisms

I fully documented everything inline.  A few changes were made to the inner workings (just splitting out some functionality into multiple methods that are re-usable and making public versions of some private functions). 

After playing around with this I realized that the various load functions need to be in both `AshesEnv` and the base `Template` class.  

So I ended up with these new functions 

Template
* from_ast (classmethod, like `from_path`)
* from_python_string (classmethod, like `from_path`)
* from_python_compiled (classmethod, like `from_path`)
* to_ast
* topython_string

BaseAshesEnv
* generate_ast
* generate_python_string
* load_template_ast
* load_template_python_string
* load_template_python_compiled

There are also some new support functions

* ashes.compile_python_string -- public interface to `ashes._python_compile`
* Template._ast_to_render_func -- split out from `Template._get_render_func`

In terms of performance...  the parsing and compiling functions are fairly expensive!

According to one suite of tests...

* caching the AST saves around 35% of execution time.
* caching the python string representation saves about 65% of execution time
* caching the python function itself and rebuilding templates off that saves 96% of execution time (!).  this approach won't work in a lot of situations, but if it works in your environment -- wow.

