### PR TITLE
Modernize CI: GitHub Actions, codecov, fix deprecated assertEquals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           cache: pip
+          cache-dependency-path: setup.py
       - run: pip install coverage
       - run: coverage run run_tests.py --run_unittests
       - run: coverage xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: Tests
+on:
+  push:
+    paths-ignore:
+      - "docs/**"
+      - "*.md"
+      - "*.rst"
+      - "*.txt"
+  pull_request:
+    paths-ignore:
+      - "docs/**"
+      - "*.md"
+      - "*.rst"
+      - "*.txt"
+jobs:
+  tests:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { name: "3.14", python: "3.14", os: ubuntu-latest }
+          - { name: "3.13", python: "3.13", os: ubuntu-latest }
+          - { name: "3.12", python: "3.12", os: ubuntu-latest }
+          - { name: "3.11", python: "3.11", os: ubuntu-latest }
+          - { name: "3.10", python: "3.10", os: ubuntu-latest }
+          - { name: "3.9", python: "3.9", os: ubuntu-latest }
+          - { name: "PyPy3", python: "pypy-3.10", os: ubuntu-latest }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+          cache: pip
+      - run: pip install coverage
+      - run: coverage run run_tests.py --run_unittests
+      - run: coverage xml
+      - name: "Upload coverage to Codecov"
+        uses: "codecov/codecov-action@v5"
+        with:
+          fail_ci_if_error: true
+          files: coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto    # must match base commit coverage
+        threshold: 0.5% # tolerate small measurement noise
+    patch:
+      default:
+        target: 100%    # new/changed lines must be covered

--- a/tests/template_loaders.py
+++ b/tests/template_loaders.py
@@ -123,7 +123,7 @@ class TestApiFunctions(unittest.TestCase):
         ashesEnv = ashes.AshesEnv(paths=self._SimpleFruitData.directory)
         for _fruit in self._SimpleFruitData.template_source.keys():
             _rendered = ashesEnv.render(_fruit, {})
-            self.assertEquals(_rendered, self._SimpleFruitData.renders_expected[_fruit])
+            self.assertEqual(_rendered, self._SimpleFruitData.renders_expected[_fruit])
 
     def test_TemplatePathLoader(self):
         """this tests an ashesEnv initialized with a `loaders=ashes.TemplatePathLoader()`"""
@@ -131,7 +131,7 @@ class TestApiFunctions(unittest.TestCase):
         ashesEnv = ashes.AshesEnv(loaders=(ashesLoader, ))
         for _fruit in self._SimpleFruitData.template_source.keys():
             _rendered = ashesEnv.render(_fruit, {})
-            self.assertEquals(_rendered, self._SimpleFruitData.renders_expected[_fruit])
+            self.assertEqual(_rendered, self._SimpleFruitData.renders_expected[_fruit])
 
     def test_template_init_source(self):
         """
@@ -142,7 +142,7 @@ class TestApiFunctions(unittest.TestCase):
             if _fruit not in self._SimpleFruitData.template_dependencies:
                 _template = ashes.Template(_fruit, self._SimpleFruitData.template_source[_fruit])
                 _rendered = _template.render({})
-                self.assertEquals(_rendered, self._SimpleFruitData.renders_expected[_fruit])
+                self.assertEqual(_rendered, self._SimpleFruitData.renders_expected[_fruit])
 
     def test_template_init_source_file(self):
         """
@@ -154,7 +154,7 @@ class TestApiFunctions(unittest.TestCase):
                 _source_file = os.path.join(self._SimpleFruitData.directory, _fruit)
                 _template = ashes.Template(_fruit, None, source_file=_source_file)
                 _rendered = _template.render({})
-                self.assertEquals(_rendered, self._SimpleFruitData.renders_expected[_fruit])
+                self.assertEqual(_rendered, self._SimpleFruitData.renders_expected[_fruit])
 
     def _helper_test_template_init__args(self, fruit, source_payload=None, source_classmethod=None):
         """helper class for _helper_test_template_init__args_* tests"""
@@ -163,7 +163,7 @@ class TestApiFunctions(unittest.TestCase):
         # can it render via classmethod?
         _template = source_classmethod(source_data)
         _rendered = _template.render({})
-        self.assertEquals(_rendered, self._SimpleFruitData.renders_expected[fruit])
+        self.assertEqual(_rendered, self._SimpleFruitData.renders_expected[fruit])
 
     def test_template_init_args_ast(self):
         """
@@ -210,13 +210,13 @@ class TestApiFunctions(unittest.TestCase):
             _template = ashesEnv.load(_fruit)
 
             _as_ast = _template.to_ast()
-            self.assertEquals(_as_ast, self._SimpleFruitData.compiled_template_data[_fruit]['ast'])
+            self.assertEqual(_as_ast, self._SimpleFruitData.compiled_template_data[_fruit]['ast'])
 
             _as_python_string = _template.to_python_string()
-            self.assertEquals(_as_python_string, self._SimpleFruitData.compiled_template_data[_fruit]['python_string'])
+            self.assertEqual(_as_python_string, self._SimpleFruitData.compiled_template_data[_fruit]['python_string'])
 
             _as_python_code = _template.to_python_code()
-            self.assertEquals(_as_python_code, self._SimpleFruitData.compiled_template_data[_fruit]['python_code'])
+            self.assertEqual(_as_python_code, self._SimpleFruitData.compiled_template_data[_fruit]['python_code'])
 
             # this will never equate, but it must run!
             _as_python_func = _template.to_python_func()


### PR DESCRIPTION
## Changes

- **GitHub Actions workflow** (`.github/workflows/ci.yml`)
  - `actions/setup-python@v5` with built-in `cache: pip` (no manual `actions/cache`)
  - `codecov/codecov-action@v5` with `CODECOV_TOKEN`
  - Matrix: Python 3.9–3.14 + PyPy 3.10
  - `paths-ignore` for docs/markdown
  - `fail_ci_if_error: true`

- **`codecov.yml`** — project threshold 0.5%, patch target 100%

- **Test fix** — `assertEquals` → `assertEqual` (8 call sites in `tests/template_loaders.py`), removed in Python 3.12+

Replaces the legacy `.travis.yml` (Python 2.6/2.7/3.3/3.4).